### PR TITLE
Publish language files into the defined lang path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The package will automatically register itself.
 
 ### Translations
 
-If you wish to edit the package translations, you can run the following command to publish them into your `resources/lang` folder
+If you wish to edit the package translations, you can run the following command to publish them into your `resources/lang` (or `/lang` in Laravel 9.x) folder
 
 ```bash
 php artisan vendor:publish --provider="Iamfarhad\Validation\ValidationRulesServiceProvider"

--- a/src/ValidationRulesServiceProvider.php
+++ b/src/ValidationRulesServiceProvider.php
@@ -9,7 +9,7 @@ class ValidationRulesServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->publishes([
-            __DIR__.'/../resources/lang' => resource_path('lang/vendor/validationRules'),
+            __DIR__.'/../resources/lang' => app()->langPath() . '/vendor/validationRules',
         ]);
 
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang/', 'validationRules');


### PR DESCRIPTION
Changed publishing in service provider according to https://laravel.com/docs/master/upgrade#the-lang-directory

I have tested this in Laravel 8.81 and it seems to work fine, support should be a non-issue considering this method has existed since [Laravel 6.x](https://laravel.com/api/6.x/Illuminate/Foundation/Application.html#method_langPath)

p.s: I ran the `composer test` command and all tests seem to pass 