### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,19 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.1, 8.2, 8.3, 8.4 ]
-        laravel: [ 10.*, 11.*, 12.* ]
+        laravel: [ 10.*, 11.*, 12.*, 13.* ]
         exclude:
           - php: 8.1
             laravel: 11.*
           - php: 8.1
             laravel: 12.*
+          - php: 8.1
+            laravel: 13.*
+          - php: 8.2
+            laravel: 13.*
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "iamfarhad/validation",
-    "description": "🇮🇷 Complete Laravel Persian validation package - Iranian national ID, mobile numbers, Shamsi dates, IBAN/Sheba, postal codes & more. Modern Laravel 10-12 support with both ValidationRule objects & string-based rules.",
+    "description": "🇮🇷 Complete Laravel Persian validation package - Iranian national ID, mobile numbers, Shamsi dates, IBAN/Sheba, postal codes & more. Modern Laravel 10-13 support with both ValidationRule objects & string-based rules.",
     "type": "library",
     "license": "MIT",
     "keywords": [
@@ -66,12 +66,12 @@
     },
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/validation": "^10.0|^11.0|^12.0"
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/validation": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0|^11.0|^12.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.0|^2.0",
         "phpstan/phpstan": "^1.10 || ^2.0",
         "laravel/pint": "^1.0"


### PR DESCRIPTION
## Summary
- Add Laravel 13 (`^13.0`) support for `illuminate/support` and `illuminate/validation`
- Add Orchestra Testbench 11 support for Laravel 13 test runs
- Extend the CI matrix to test Laravel 13 on supported PHP versions
- Exclude Laravel 13 from PHP 8.1 and 8.2 because Laravel 13 requires PHP 8.3+

## Notes
Laravel 13 requires PHP 8.3+, but the package-level PHP requirement remains `^8.1` so existing Laravel 10-12 users are not blocked. Composer will still enforce PHP 8.3+ when Laravel 13 dependencies are selected.

## Testing
- Not run locally: sandbox could not resolve `github.com` for cloning the repository.
- GitHub Actions should validate the expanded matrix on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only widens dependency constraints and CI test matrix; no runtime logic changes, with potential risk limited to version-constraint/resolution issues.
> 
> **Overview**
> Adds **Laravel 13 compatibility** by widening `illuminate/support` and `illuminate/validation` constraints to include `^13.0` and updating the package description accordingly.
> 
> Expands GitHub Actions CI to test against `laravel: 13.*`, wiring it to `orchestra/testbench: 11.*` and excluding unsupported PHP/Laravel combinations (Laravel 13 not run on PHP 8.1/8.2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3026bbde6a9ea087319a6aece589863f691bc45c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->